### PR TITLE
Adds ability to rename lights in Studio

### DIFF
--- a/Graphics/Shared/Inspector/LightInspector.cs
+++ b/Graphics/Shared/Inspector/LightInspector.cs
@@ -70,7 +70,14 @@ namespace Graphics.Inspector
                                 {
                                     alloyLight = lightManager.SelectedLight.light.GetComponent<AlloyAreaLight>();
                                 }
-                                Label(lightManager.SelectedLight.light.name, "", true);
+                                if (Graphics.Instance.IsStudio())
+                                {
+                                    Text("Light Name", lightManager.SelectedLight.light.name, lightName => lightManager.SelectedLight.light.name = lightName, !lightManager.SelectedLight.light.transform.IsChildOf(GameObject.Find("StudioScene/Camera").transform));
+                                }
+                                else
+                                {
+                                    Label(lightManager.SelectedLight.light.name, "", true);
+                                }
                                 GUILayout.BeginVertical(GUIStyles.Skin.box);
                                 inspectorScrollView = GUILayout.BeginScrollView(inspectorScrollView);
                                 {
@@ -119,7 +126,7 @@ namespace Graphics.Inspector
                                             GUI.enabled = true;
                                         }
 
-                                        if (lightManager.SelectedLight.light.name != "Cam Light")
+                                        if (lightManager.SelectedLight.light.name != "Cam Light" || !lightManager.SelectedLight.light.transform.IsChildOf(GameObject.Find("StudioScene/Camera").transform))
                                         {
                                             Vector3 rot = lightManager.SelectedLight.rotation;
                                             Slider("Vertical Rotation", rot.x, LightSettings.RotationXMin, LightSettings.RotationXMax, "N1", x => { rot.x = x; });

--- a/Graphics/Shared/Setting/PerLightSettings.cs
+++ b/Graphics/Shared/Setting/PerLightSettings.cs
@@ -13,6 +13,7 @@ namespace Graphics
     {
         public bool Disabled { get; set; } = true;
         public bool UseAlloyLight { get; set; }
+        public string LightName { get; set; }
         public Color Color { get; set; }
         public float ColorTemperature { get; set; }
         public int ShadowType { get; set; }
@@ -38,6 +39,8 @@ namespace Graphics
             lightObject.enabled = !Disabled;
 
             Graphics.Instance.LightManager.UseAlloyLight = UseAlloyLight;
+
+            if (!string.IsNullOrEmpty(LightName)) lightObject.light.name = LightName;
 
             lightObject.color = Color;
             lightObject.light.colorTemperature = ColorTemperature;
@@ -68,7 +71,7 @@ namespace Graphics
             }
 
             // Exclude Cam Light from rotation setting
-            if (lightObject.light.name != "Cam Light")
+            if (lightObject.light.name != "Cam Light" && !lightObject.light.transform.IsChildOf(GameObject.Find("StudioScene/Camera").transform))
                 lightObject.rotation = Rotation;
 
             lightObject.range = Range;
@@ -91,6 +94,8 @@ namespace Graphics
             Disabled = !lightObject.enabled;
 
             UseAlloyLight = Graphics.Instance.LightManager.UseAlloyLight;
+
+            LightName = lightObject.light.name;
 
             Color = lightObject.color;
             ColorTemperature = lightObject.light.colorTemperature;


### PR DESCRIPTION
Lets users customize the name for all lights in Studio, except for lights under "StudioScene/Camera" to prevent conflicts with anything that might rely on the names of those lights. Light names are saved with scenes.

Please review at your convenience. Thanks!